### PR TITLE
Demo de virtual threads (Loom) com observabilidade comparativa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /.idea/
 /datomic-database/docker/tools/.cpcache/
+/.claude/
+**/.clj-kondo/
+etc/load_test/*.bin

--- a/clojure-api/Dockerfile
+++ b/clojure-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure
+FROM clojure:temurin-21-lein
 COPY . /usr/src/app
 WORKDIR /usr/src/app
 RUN mv "$(lein uberjar | sed -n 's/^Created \(.*standalone\.jar\)/\1/p')" app-standalone.jar

--- a/clojure-api/project.clj
+++ b/clojure-api/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[environ "1.1.0"]
-                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/clojure "1.11.4"]
                  [org.clojure/test.check "0.9.0"]
                  [prismatic/schema-generators "0.1.5"]
                  [ring-mock "0.1.5"]

--- a/clojure-api/src/com/code4nimbus/clojureapi/diplomat/http_server.clj
+++ b/clojure-api/src/com/code4nimbus/clojureapi/diplomat/http_server.clj
@@ -2,6 +2,7 @@
   (:require [clojure.data.json :as json]
             [com.code4nimbus.clojureapi.adapters.product :as adapters.product]
             [com.code4nimbus.clojureapi.controller.product :as controller.product]
+            [com.code4nimbus.clojureapi.logic.loom :as loom]
             [com.code4nimbus.clojureapi.logic.metrics :refer [prometheus-registry]]
             [com.code4nimbus.clojureapi.wire.in.product :as wire.in.product]
             [compojure.api.sweet :refer :all]
@@ -113,4 +114,13 @@
      :path-params [id :- Long]
      (prometheus/with-duration
        (prometheus-registry :code4nimbus-clojureapi/delete-product-seconds)
-       (delete-product! connection id)))])
+       (delete-product! connection id)))
+   ;; Virtual-threads demo: fan out `tasks` blocking jobs on a platform or
+   ;; virtual executor. `mode` defaults to this container's THREAD_MODE.
+   (GET "/load" []
+     :query-params [{mode :- String ""}
+                    {tasks :- Long 500}
+                    {sleepMs :- Long 200}]
+     {:status  200
+      :headers {"Content-Type" "application/json", "Access-Control-Allow-Origin" "*"}
+      :body    (json/write-str (loom/run-batch! mode tasks sleepMs))})])

--- a/clojure-api/src/com/code4nimbus/clojureapi/logic/loom.clj
+++ b/clojure-api/src/com/code4nimbus/clojureapi/logic/loom.clj
@@ -1,0 +1,57 @@
+(ns com.code4nimbus.clojureapi.logic.loom
+  "Load generator used to compare platform threads vs JDK 21 virtual threads.
+   Fans out N blocking jobs (each sleeps to simulate I/O) on an executor chosen
+   by `mode`, and instruments the in-flight task count and batch wall-clock so
+   the contrast is visible in Prometheus/Grafana."
+  (:require [clojure.string :as str]
+            [com.code4nimbus.clojureapi.logic.metrics :refer [prometheus-registry]]
+            [iapetos.core :as prometheus])
+  (:import (java.util.concurrent Callable ExecutorService Executors Future)))
+
+;; Default mode for this JVM, set per container via docker-compose.
+(def ^:private container-mode
+  (or (System/getenv "THREAD_MODE") "platform"))
+
+(defn ^:private normalize-mode
+  "An explicit ?mode= wins; otherwise fall back to this container's THREAD_MODE."
+  [mode]
+  (let [m (some-> mode str/lower-case str/trim)]
+    (if (#{"platform" "virtual"} m) m container-mode)))
+
+(defn ^:private ^ExecutorService executor-for
+  [mode n-tasks]
+  (if (= "virtual" mode)
+    (Executors/newVirtualThreadPerTaskExecutor)
+    ;; A bounded pool of real OS threads: this is what saturates under load and
+    ;; makes jvm_threads_current spike while jobs queue up.
+    (Executors/newFixedThreadPool (max 1 (min (int n-tasks) 200)))))
+
+(defn run-batch!
+  "Run `n-tasks` blocking jobs (each sleeps `sleep-ms` ms) on a platform or
+   virtual executor; block until all finish; return a result map. Holds
+   loom_inflight_tasks{mode} up while jobs run and records loom_batch_seconds{mode}."
+  [mode n-tasks sleep-ms]
+  (let [mode     (normalize-mode mode)
+        n-tasks  (max 1 (int n-tasks))
+        sleep-ms (max 0 (long sleep-ms))
+        inflight (prometheus-registry :loom/inflight-tasks {:mode mode})
+        pool     (executor-for mode n-tasks)]
+    (try
+      (prometheus/with-duration
+        (prometheus-registry :loom/batch-seconds {:mode mode})
+        (let [start (System/nanoTime)
+              jobs  (mapv (fn [_]
+                            (reify Callable
+                              (call [_]
+                                (prometheus/inc inflight)
+                                (try (Thread/sleep sleep-ms) "ok"
+                                     (finally (prometheus/dec inflight))))))
+                          (range n-tasks))]
+          (doseq [^Future f (.invokeAll pool jobs)]
+            (.get f))
+          {:mode      mode
+           :tasks     n-tasks
+           :sleepMs   sleep-ms
+           :elapsedMs (/ (- (System/nanoTime) start) 1e6)}))
+      (finally
+        (.shutdown pool)))))

--- a/clojure-api/src/com/code4nimbus/clojureapi/logic/metrics.clj
+++ b/clojure-api/src/com/code4nimbus/clojureapi/logic/metrics.clj
@@ -15,4 +15,8 @@
                (prometheus/summary :code4nimbus-clojureapi/add-product-seconds)
                (prometheus/summary :code4nimbus-clojureapi/update-product-seconds)
                (prometheus/summary :code4nimbus-clojureapi/delete-product-seconds)
-               (prometheus/summary :code4nimbus-clojureapi/generate-random-products-seconds))))
+               (prometheus/summary :code4nimbus-clojureapi/generate-random-products-seconds)
+               ;; Virtual-threads demo (see logic.loom): in-flight task count and
+               ;; per-batch wall-clock, both split by thread mode.
+               (prometheus/gauge :loom/inflight-tasks {:labels [:mode]})
+               (prometheus/summary :loom/batch-seconds {:labels [:mode]}))))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,27 @@ services:
     environment:
       DATOMIC_URL: datomic:dev://datomic-transactor:4334/product/?password=unsafe
       BOOTSTRAP_SERVER: kafka:9092
+      THREAD_MODE: platform
+    cpus: 1.0
     ports:
       - "9000:9000"
+    depends_on:
+      - kafka
+      - prometheus
+
+  clojure-api-vt:
+    build: clojure-api
+    links:
+      - prometheus
+      - datomic-transactor
+      - kafka
+    environment:
+      DATOMIC_URL: datomic:dev://datomic-transactor:4334/product/?password=unsafe
+      BOOTSTRAP_SERVER: kafka:9092
+      THREAD_MODE: virtual
+    cpus: 1.0
+    ports:
+      - "9002:9000"
     depends_on:
       - kafka
       - prometheus
@@ -116,6 +135,21 @@ services:
       - jmx-kafka-cluster
     ports:
       - 9090:9090
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    container_name: cadvisor
+    privileged: true
+    ports:
+      - "8081:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      - prometheus
 
   grafana:
     image: grafana/grafana:9.5.12

--- a/docs/virtual-threads.md
+++ b/docs/virtual-threads.md
@@ -1,0 +1,198 @@
+# Virtual Threads — Demo do Loom (Plataforma vs. Virtual)
+
+Runbook passo a passo para demonstrar a diferença entre **platform threads**
+(threads tradicionais da JVM) e **virtual threads** (Project Loom, JDK 21) sob
+carga concorrente de I/O bloqueante.
+
+## O que a demo mostra
+
+Dois serviços idênticos rodam o mesmo endpoint de carga, mas com pools de threads
+diferentes:
+
+- **`clojure-api`** (porta `9000`, `THREAD_MODE=platform`): cada tarefa bloqueante
+  consome uma **platform thread** real do sistema operacional. Sob alta
+  concorrência, o número de threads explode e a latência cresce, pois o pool fica
+  saturado (limitado a 200 threads) e as tarefas precisam esperar por uma thread
+  livre.
+- **`clojure-api-vt`** (porta `9002`, `THREAD_MODE=virtual`): cada tarefa roda em
+  uma **virtual thread**. Milhares de tarefas bloqueantes podem rodar
+  simultaneamente sem inflar o número de threads de plataforma, porque a JVM
+  desacopla a virtual thread da carrier thread durante o bloqueio de I/O.
+
+O endpoint usado nos dois serviços é:
+
+```
+GET /load?mode=platform|virtual&tasks=<int>&sleepMs=<int>
+```
+
+Ele dispara `tasks` jobs bloqueantes (cada um dorme `sleepMs` milissegundos) no
+pool de threads selecionado por `mode`, simulando I/O bloqueante concorrente, e
+bloqueia até o lote inteiro terminar (`invokeAll`). A implementação está em
+`clojure-api/src/com/code4nimbus/clojureapi/logic/loom.clj`:
+
+- `mode=platform` → `Executors/newFixedThreadPool` (máx. 200 threads de SO).
+- `mode=virtual`  → `Executors/newVirtualThreadPerTaskExecutor` (1 virtual thread
+  por job).
+
+> Importante: só o **fan-out interno** dos jobs usa o executor configurável. O
+> servidor HTTP (httpkit) é o mesmo nos dois serviços — ou seja, a demo isola a
+> diferença no ponto onde o I/O bloqueante acontece.
+
+## Limite de CPU (para ver throttling)
+
+No `docker-compose.yml`, ambos os serviços têm `cpus: 1.0` (1 núcleo). Isso é o
+que torna o **CPU throttling** visível sob carga: quando o container estoura seu
+núcleo, o kernel (CFS) o bloqueia, e o cAdvisor reporta esse tempo bloqueado.
+
+## Observabilidade
+
+O `docker-compose.yml` sobe a stack de métricas:
+
+- **Prometheus** (`9090`) — coleta as métricas dos dois serviços e do **cAdvisor**.
+- **cAdvisor** (`8081`) — expõe métricas de cgroup por container (CPU, memória e,
+  principalmente, **CPU throttling**). Precisa do socket do Docker montado para
+  resolver os nomes dos containers (`/var/run/docker.sock`).
+- **Grafana** (`3000`) — dashboard **"Virtual Threads — Loom Demo"**
+  (uid `loom-threads`), provisionado de `grafana/dashboards/loom_threads.json`.
+
+## Pré-requisitos
+
+- **Docker** (com `docker compose`).
+- **vegeta** para gerar a carga — veja https://github.com/tsenart/vegeta.
+- **JDK 21** já vem dentro dos containers; não é necessário instalar
+  Java/Clojure/lein localmente.
+
+## 1. Build e subida dos serviços
+
+```sh
+docker compose up --build clojure-api clojure-api-vt prometheus cadvisor grafana
+```
+
+Os serviços dependem de `kafka`, `zookeeper` e `datomic-transactor` (conforme o
+`docker-compose.yml`), iniciados automaticamente como dependências.
+
+Serviços relevantes após a subida:
+
+- `clojure-api`      → http://localhost:9000 (platform threads)
+- `clojure-api-vt`   → http://localhost:9002 (virtual threads)
+- Prometheus         → http://localhost:9090
+- cAdvisor           → http://localhost:8081
+- Grafana            → http://localhost:3000 (admin/admin)
+
+## 2. Rodar a carga
+
+Com os serviços no ar, dispare os dois ataques **em paralelo** (platform e
+virtual ao mesmo tempo) com o script:
+
+```sh
+etc/load_test/run-both.sh
+```
+
+O script:
+
+- verifica se o `vegeta` está instalado;
+- roda os dois ataques simultaneamente (`&` + `wait`);
+- grava os resultados binários (`results-platform.bin`, `results-virtual.bin`,
+  ignorados pelo git);
+- imprime o `vegeta report` de cada um ao final.
+
+É possível ajustar a intensidade via variáveis de ambiente:
+
+```sh
+RATE=40 DURATION=120s etc/load_test/run-both.sh
+```
+
+## 3. Abrir o Grafana
+
+Acesse http://localhost:3000 (usuário `admin`, senha `admin`) e abra o dashboard
+**"Virtual Threads — Loom Demo"** (uid `loom-threads`), ou diretamente:
+http://localhost:3000/d/loom-threads
+
+## 4. O que observar
+
+Compare os dois serviços lado a lado enquanto a carga roda. Painéis do dashboard:
+
+**Threads e tarefas**
+- `jvm_threads_current` — platform threads da JVM. **Dispara** no modo platform;
+  fica **estável e baixo** no virtual (poucas carriers carregam milhares de
+  virtual threads).
+- `loom_inflight_tasks{mode}` — tarefas concorrentes em andamento por modo.
+- `loom_batch_seconds{mode}` — tempo de execução do lote por modo.
+
+**JVM por container**
+- Heap usado, memória residente (RSS) e tempo em GC — o lado virtual mantém mais
+  tarefas vivas ao mesmo tempo, então tende a usar mais heap/RSS.
+
+**CPU e throttling (cAdvisor)**
+- **CPU % do limite (1 core)** — `100 * rate(container_cpu_usage_seconds_total) /
+  (quota/period)`. 100% = container saturou o núcleo.
+- **CPU throttling (s/s)** — `rate(container_cpu_cfs_throttled_seconds_total)`.
+- **% de períodos CFS throttled** — fração dos períodos de agendamento em que o
+  container bateu no teto de CPU.
+
+**HTTP**
+- **HTTP por endpoint + status** — `sum by (job,path,status)
+  (rate(http_requests_total[1m]))`.
+- **Status class por container (2XX/4XX/5XX)** — proporção de sucesso vs. erro.
+
+## 5. Resultados observados
+
+Medições em um MacBook (Docker Desktop, 6 vCPUs disponíveis à VM).
+
+### Carga leve, sem limite de CPU — 20 req/s × 30s (600 req/lado)
+
+| Métrica          | Platform        | Virtual        |
+| ---------------- | --------------- | -------------- |
+| Sucesso          | 21,67% (130)    | **100% (600)** |
+| Throughput       | 2,17 req/s      | **17,38 req/s**|
+| Latência média   | 26,6 s          | **1,94 s**     |
+| Timeouts (30s)   | 470/600         | **0**          |
+
+O pool de 200 platform threads satura imediatamente (cada requisição enfileira
+500 jobs); o virtual absorve toda a carga sem erro. Durante o pico, o scrape do
+`clojure-api` chega a ficar **DOWN** no Prometheus — o container está saturado
+demais para responder até o `/metrics`.
+
+### Carga pesada, com limite de 1 core — 40 req/s × 120s (4800 req/lado)
+
+| Métrica          | Platform       | Virtual         |
+| ---------------- | -------------- | --------------- |
+| Sucesso          | 3,06% (147)    | **21,60% (1037)** |
+| Throughput       | 0,98 req/s     | **6,91 req/s**  |
+| Timeouts (30s)   | 4653/4800      | 3763/4800       |
+
+Picos no meio do teste (cAdvisor):
+
+| Métrica                 | Platform   | Virtual |
+| ----------------------- | ---------- | ------- |
+| CPU % do limite         | **58,8%**  | 44,7%   |
+| CPU throttling (s/s)    | **0,152**  | 0,028   |
+| % de períodos throttled | **17,1%**  | 8,7%    |
+
+Com o mesmo limite de CPU, os dois lados saturam — mas o virtual entrega **~7×
+mais requisições com sucesso**. O platform **queima mais CPU** (mais
+context-switch entre centenas de threads de SO bloqueadas) para fazer **menos**
+trabalho útil, e por isso é **throttled com ~2× mais frequência**.
+
+> Observação: a 40 req/s × 500 jobs chegam ~20.000 jobs/s; o virtual também
+> começa a estourar o timeout de 30s do vegeta porque o gargalo deixa de ser o
+> número de threads e passa a ser CPU/coordenação. Para um contraste "limpo"
+> (virtual perto de 100%, platform afundando), use uma taxa intermediária, ex.
+> `RATE=25 DURATION=60s`.
+
+## 6. Ajuste fino (tuning)
+
+Os "botões" da demo controlam a intensidade e o formato da carga:
+
+- **`tasks`** (em `etc/load_test/attack-*.txt`): número de jobs bloqueantes por
+  requisição. Aumente para acentuar a saturação do pool de platform threads.
+- **`sleepMs`** (em `etc/load_test/attack-*.txt`): duração do bloqueio de cada
+  job. Valores maiores prolongam o I/O simulado e ampliam a diferença entre os
+  modos.
+- **`RATE`** (env do `run-both.sh`): requisições por segundo do vegeta.
+- **`DURATION`** (env do `run-both.sh`): duração de cada ataque. Use durações
+  maiores para enxergar o regime estacionário nos gráficos.
+
+> Dica: para alterar `tasks`/`sleepMs`, edite as linhas em
+> `etc/load_test/attack-platform.txt` e `etc/load_test/attack-virtual.txt`
+> (mantendo `mode=platform` na porta 9000 e `mode=virtual` na porta 9002).

--- a/etc/load_test/attack-platform.txt
+++ b/etc/load_test/attack-platform.txt
@@ -1,0 +1,1 @@
+GET http://localhost:9000/load?mode=platform&tasks=500&sleepMs=200

--- a/etc/load_test/attack-virtual.txt
+++ b/etc/load_test/attack-virtual.txt
@@ -1,0 +1,1 @@
+GET http://localhost:9002/load?mode=virtual&tasks=500&sleepMs=200

--- a/etc/load_test/run-both.sh
+++ b/etc/load_test/run-both.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# run-both.sh
+#
+# Runs two vegeta attacks IN PARALLEL against the virtual-threads demo:
+#   - platform threads  -> http://localhost:9000 (clojure-api,    THREAD_MODE=platform)
+#   - virtual  threads  -> http://localhost:9002 (clojure-api-vt, THREAD_MODE=virtual)
+#
+# Both flows run simultaneously so you can compare their behaviour in Grafana
+# (dashboard "Virtual Threads — Loom Demo", uid loom-threads).
+#
+# Override RATE / DURATION via env vars, e.g.:
+#   RATE=40 DURATION=60s ./run-both.sh
+#
+set -euo pipefail
+
+# --- configuration (overridable via env) -----------------------------------
+RATE="${RATE:-20}"
+DURATION="${DURATION:-30s}"
+
+# Resolve the directory this script lives in so it can be invoked from anywhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PLATFORM_TARGETS="${SCRIPT_DIR}/attack-platform.txt"
+VIRTUAL_TARGETS="${SCRIPT_DIR}/attack-virtual.txt"
+
+PLATFORM_BIN="${SCRIPT_DIR}/results-platform.bin"
+VIRTUAL_BIN="${SCRIPT_DIR}/results-virtual.bin"
+
+# --- preflight checks -------------------------------------------------------
+if ! command -v vegeta >/dev/null 2>&1; then
+  echo "ERROR: vegeta is not installed or not on PATH." >&2
+  echo "       Install it: https://github.com/tsenart/vegeta" >&2
+  exit 1
+fi
+
+for f in "${PLATFORM_TARGETS}" "${VIRTUAL_TARGETS}"; do
+  if [[ ! -f "${f}" ]]; then
+    echo "ERROR: targets file not found: ${f}" >&2
+    exit 1
+  fi
+done
+
+echo "Starting parallel vegeta attacks (rate=${RATE}, duration=${DURATION})..."
+echo "  platform -> $(cat "${PLATFORM_TARGETS}")"
+echo "  virtual  -> $(cat "${VIRTUAL_TARGETS}")"
+echo
+
+# --- run both attacks in parallel ------------------------------------------
+vegeta attack -targets="${PLATFORM_TARGETS}" -rate="${RATE}" -duration="${DURATION}" \
+  | tee "${PLATFORM_BIN}" >/dev/null &
+PLATFORM_PID=$!
+
+vegeta attack -targets="${VIRTUAL_TARGETS}" -rate="${RATE}" -duration="${DURATION}" \
+  | tee "${VIRTUAL_BIN}" >/dev/null &
+VIRTUAL_PID=$!
+
+# Wait for both attacks to finish; surface a failure of either one.
+status=0
+wait "${PLATFORM_PID}" || status=$?
+wait "${VIRTUAL_PID}"  || status=$?
+
+# --- reports ----------------------------------------------------------------
+echo
+echo "================ PLATFORM (port 9000) ================"
+vegeta report "${PLATFORM_BIN}"
+
+echo
+echo "================ VIRTUAL  (port 9002) ================"
+vegeta report "${VIRTUAL_BIN}"
+
+exit "${status}"

--- a/grafana/dashboards/loom_threads.json
+++ b/grafana/dashboards/loom_threads.json
@@ -1,0 +1,1157 @@
+{
+ "annotations": {
+  "list": [
+   {
+    "builtIn": 1,
+    "datasource": "-- Grafana --",
+    "enable": true,
+    "hide": true,
+    "iconColor": "rgba(0, 211, 255, 1)",
+    "name": "Annotations & Alerts",
+    "type": "dashboard"
+   }
+  ]
+ },
+ "description": "JVM threads and virtual-threads (Loom) load demo. Compare platform vs virtual scrape jobs by the job label.",
+ "editable": true,
+ "fiscalYearStartMonth": 0,
+ "graphTooltip": 0,
+ "id": null,
+ "links": [],
+ "liveNow": false,
+ "panels": [
+  {
+   "datasource": "Prometheus",
+   "description": "Headline panel: platform thread count. Platform mode spikes, virtual mode stays flat.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 0,
+    "y": 0
+   },
+   "id": 1,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "jvm_threads_current",
+     "legendFormat": "{{job}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Platform threads (JVM)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": "Prometheus",
+   "description": "In-flight tasks by scrape job and execution mode.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 12,
+    "y": 0
+   },
+   "id": 2,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "loom_inflight_tasks",
+     "legendFormat": "{{job}} {{mode}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "In-flight tasks",
+   "type": "timeseries"
+  },
+  {
+   "datasource": "Prometheus",
+   "description": "Average batch latency in seconds, derived from the loom_batch_seconds summary.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "s"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 0,
+    "y": 9
+   },
+   "id": 3,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "rate(loom_batch_seconds_sum[1m]) / rate(loom_batch_seconds_count[1m])",
+     "legendFormat": "{{job}} {{mode}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Batch latency (avg s)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": "Prometheus",
+   "description": "JVM thread states by scrape job and state.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 12,
+    "y": 9
+   },
+   "id": 4,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "jvm_threads_state",
+     "legendFormat": "{{job}} {{state}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Thread states",
+   "type": "timeseries"
+  },
+  {
+   "datasource": "Prometheus",
+   "description": "jvm_memory_bytes_used{area=\"heap\"} por job (container).",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "decbytes"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 0,
+    "y": 18
+   },
+   "id": 5,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "jvm_memory_bytes_used{area=\"heap\", job=~\"clojure-api.*\"}",
+     "legendFormat": "{{job}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Heap usado por container",
+   "type": "timeseries"
+  },
+  {
+   "datasource": "Prometheus",
+   "description": "rate(process_cpu_seconds_total[1m]) = fracao de CPU usada por container.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "percentunit"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 12,
+    "y": 18
+   },
+   "id": 6,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "rate(process_cpu_seconds_total{job=~\"clojure-api.*\"}[1m])",
+     "legendFormat": "{{job}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "CPU por container (cores)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": "Prometheus",
+   "description": "process_resident_memory_bytes por job (memoria fisica do processo).",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "decbytes"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 0,
+    "y": 27
+   },
+   "id": 7,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "process_resident_memory_bytes{job=~\"clojure-api.*\"}",
+     "legendFormat": "{{job}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Memoria residente (RSS) por container",
+   "type": "timeseries"
+  },
+  {
+   "datasource": "Prometheus",
+   "description": "rate(jvm_gc_collection_seconds_sum[1m]) = fracao de tempo gasto em GC.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "percentunit"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 12,
+    "y": 27
+   },
+   "id": 8,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "rate(jvm_gc_collection_seconds_sum{job=~\"clojure-api.*\"}[1m])",
+     "legendFormat": "{{job}} {{gc}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Tempo em GC por container",
+   "type": "timeseries"
+  },
+  {
+   "datasource": "Prometheus",
+   "description": "rate(container_cpu_cfs_throttled_seconds_total[1m]) por container (cAdvisor). Tempo que o cgroup ficou bloqueado pelo limite de CPU.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "percentunit"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 0,
+    "y": 36
+   },
+   "id": 9,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "rate(container_cpu_cfs_throttled_seconds_total{name=~\"code4nimbus-clojure-api.*\"}[1m])",
+     "legendFormat": "{{name}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "CPU throttling (s/s)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": "Prometheus",
+   "description": "rate(throttled_periods)/rate(periods) por container. Fracao dos periodos de agendamento em que o container bateu no teto de CPU.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "percentunit"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 12,
+    "y": 36
+   },
+   "id": 10,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "rate(container_cpu_cfs_throttled_periods_total{name=~\"code4nimbus-clojure-api.*\"}[1m]) / rate(container_cpu_cfs_periods_total{name=~\"code4nimbus-clojure-api.*\"}[1m])",
+     "legendFormat": "{{name}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "% de periodos CFS throttled",
+   "type": "timeseries"
+  },
+  {
+   "datasource": "Prometheus",
+   "description": "sum by (job,path,status) (rate(http_requests_total[1m])). Taxa de requisicoes por container, endpoint e codigo HTTP.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 10,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "reqps"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 0,
+    "y": 45
+   },
+   "id": 11,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "sum by (job, path, status) (rate(http_requests_total[1m]))",
+     "legendFormat": "{{job}} \u00b7 {{path}} \u00b7 {{status}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "HTTP por endpoint + status (req/s)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": "Prometheus",
+   "description": "sum by (job,statusClass) (rate(http_requests_total[1m])). Empilhado: proporcao de sucesso vs erro por container.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 40,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "normal"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     },
+     "unit": "reqps"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 12,
+    "y": 45
+   },
+   "id": 12,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "sum by (job, statusClass) (rate(http_requests_total[1m]))",
+     "legendFormat": "{{job}} \u00b7 {{statusClass}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Status class por container (2XX/4XX/5XX)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": "Prometheus",
+   "description": "100 * uso de CPU / limite do cgroup (cAdvisor). 100% = container saturou seu 1 core e passa a sofrer throttling (ver painel CPU throttling).",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 20,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "dashed"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "orange",
+        "value": 80
+       },
+       {
+        "color": "red",
+        "value": 100
+       }
+      ]
+     },
+     "unit": "percent",
+     "max": 100
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 12,
+    "x": 0,
+    "y": 54
+   },
+   "id": 13,
+   "options": {
+    "legend": {
+     "calcs": [],
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "none"
+    }
+   },
+   "targets": [
+    {
+     "datasource": "Prometheus",
+     "editorMode": "code",
+     "expr": "100 * sum by (name) (rate(container_cpu_usage_seconds_total{name=~\"code4nimbus-clojure-api.*\"}[1m])) / (sum by (name) (container_spec_cpu_quota{name=~\"code4nimbus-clojure-api.*\"}) / sum by (name) (container_spec_cpu_period{name=~\"code4nimbus-clojure-api.*\"}))",
+     "legendFormat": "{{name}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "CPU % do limite (1 core) por container",
+   "type": "timeseries"
+  }
+ ],
+ "refresh": "5s",
+ "schemaVersion": 38,
+ "style": "dark",
+ "tags": [
+  "loom",
+  "jvm",
+  "threads"
+ ],
+ "templating": {
+  "list": []
+ },
+ "time": {
+  "from": "now-15m",
+  "to": "now"
+ },
+ "timepicker": {
+  "refresh_intervals": [
+   "5s",
+   "10s",
+   "30s",
+   "1m",
+   "5m",
+   "15m",
+   "30m",
+   "1h"
+  ]
+ },
+ "timezone": "",
+ "title": "Virtual Threads \u2014 Loom Demo",
+ "uid": "loom-threads",
+ "version": 6,
+ "weekStart": ""
+}

--- a/prometheus/config/prometheus.yml
+++ b/prometheus/config/prometheus.yml
@@ -11,6 +11,14 @@ scrape_configs:
     scrape_interval: 5s
     static_configs:
     - targets: ['clojure-api:9000']
+  - job_name: 'clojure-api-vt'
+    scrape_interval: 5s
+    static_configs:
+    - targets: ['clojure-api-vt:9000']
+  - job_name: 'cadvisor'
+    scrape_interval: 5s
+    static_configs:
+    - targets: ['cadvisor:8080']
   - job_name: 'kafka-cluster'
     static_configs:
       - targets: ['jmx-kafka-cluster:5566']


### PR DESCRIPTION
## O que é

Demo que compara **platform threads** vs **virtual threads** (Project Loom, JDK 21)
sob carga de I/O bloqueante concorrente, com métricas e dashboard prontos para
visualizar a diferença em tempo real.

Dois serviços idênticos rodam o mesmo endpoint de carga, mudando só o executor:

| Serviço          | Porta | `THREAD_MODE` | Executor |
| ---------------- | ----- | ------------- | -------- |
| `clojure-api`    | 9000  | `platform`    | `FixedThreadPool` (máx. 200 threads de SO) |
| `clojure-api-vt` | 9002  | `virtual`     | `VirtualThreadPerTaskExecutor` (1 vthread/job) |

O endpoint `GET /load?mode=&tasks=&sleepMs=` faz fan-out de `tasks` jobs
bloqueantes (cada um dorme `sleepMs`) e bloqueia até o lote terminar. Só o
**fan-out interno** muda de executor — o servidor HTTP (httpkit) é o mesmo nos
dois, isolando a diferença no ponto do I/O bloqueante.

## O que está incluído

- **`logic/loom.clj`** — endpoint `/load` + métricas `loom_inflight_tasks{mode}` e
  `loom_batch_seconds{mode}`.
- **docker-compose** — serviço `clojure-api-vt`, **limite de 1 core** nos dois
  serviços e **cAdvisor** (CPU/throttling por container).
- **prometheus** — scrape do `clojure-api-vt` e do `cadvisor`.
- **grafana** — dashboard *"Virtual Threads — Loom Demo"* (`uid: loom-threads`):
  threads, in-flight, latência de batch, heap/RSS/GC, **CPU %**, **CPU
  throttling** e **status HTTP por endpoint**.
- **Dockerfile / project.clj** — base `temurin-21-lein` e Clojure 1.11.4 (JDK 21).
- **`etc/load_test/run-both.sh`** — ataque vegeta paralelo (platform + virtual).
- **`docs/virtual-threads.md`** — runbook completo, o que observar e resultados.

## O que foi observado

**Carga leve, sem limite de CPU — 20 req/s × 30s (600 req/lado):**

| Métrica        | Platform     | Virtual         |
| -------------- | ------------ | --------------- |
| Sucesso        | 21,67% (130) | **100% (600)**  |
| Throughput     | 2,17 req/s   | **17,38 req/s** |
| Latência média | 26,6 s       | **1,94 s**      |
| Timeouts       | 470/600      | **0**           |

**Carga pesada, com limite de 1 core — 40 req/s × 120s (4800 req/lado):**

| Métrica    | Platform    | Virtual           |
| ---------- | ----------- | ----------------- |
| Sucesso    | 3,06% (147) | **21,60% (1037)** |
| Throughput | 0,98 req/s  | **6,91 req/s**    |

Picos no meio do teste (cAdvisor): CPU% **58,8%** (platform) vs 44,7% (virtual);
throttling **0,152 s/s** vs 0,028; períodos throttled **17,1%** vs 8,7%.

Resumo: com o mesmo limite de CPU, o virtual entrega **~7× mais sucessos**. O
platform queima mais CPU em context-switch entre centenas de threads de SO
bloqueadas para fazer menos trabalho útil — e é throttled ~2× mais.

## Como testar

```sh
# 1. Subir a stack (JDK 21 já vem nos containers; precisa de Docker + vegeta)
docker compose up --build clojure-api clojure-api-vt prometheus cadvisor grafana

# 2. Disparar os dois ataques em paralelo
RATE=40 DURATION=120s etc/load_test/run-both.sh

# 3. Abrir o dashboard
#    http://localhost:3000/d/loom-threads  (admin/admin)
```

Para um contraste "limpo" (virtual perto de 100%, platform afundando), use uma
taxa intermediária: `RATE=25 DURATION=60s etc/load_test/run-both.sh`.

Detalhes completos, lista de painéis e tuning em `docs/virtual-threads.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)