### PR TITLE
fix(bff): corrige erros de TypeScript que quebravam o build

### DIFF
--- a/clojure-api-bff/src/App.tsx
+++ b/clojure-api-bff/src/App.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Button } from "./components/ui/button";
 import { Input } from "./components/ui/input";
 import { Search, PlusCircle } from "lucide-react"
-import { useNavigate } from "react-router-dom";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./components/ui/table";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "./components/ui/dialog";
 import { Label } from "./components/ui/label";
@@ -36,7 +35,6 @@ export function App() {
   } , [])
 
   const [formData, setFormData] = useState(initialValue);
-  //const navigate = useNavigate();
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     
@@ -47,7 +45,7 @@ export function App() {
 
   }
 
-  function onSubmit(ev: React.FormEvent<HTMLInputElement>){
+  function onSubmit(ev: React.FormEvent<HTMLFormElement>){
 
     ev.preventDefault();
 


### PR DESCRIPTION
## Contexto

Ao validar os builds localmente (já que o GitHub Actions está bloqueado por
billing na conta e não consegue rodar nada), o build do `clojure-api-bff`
falhava — mas **não por causa do vite 6**. Falhava no passo `tsc` do script
`tsc && vite build`, com dois erros reais de TypeScript em `src/App.tsx`:

```
src/App.tsx(5,1):  error TS6133: 'useNavigate' is declared but its value is never read.
src/App.tsx(94,41): error TS2322: Type '(ev: FormEvent<HTMLInputElement>) => void'
                    is not assignable to type 'FormEventHandler<HTMLFormElement>'.
```

Esses erros nunca apareceram no CI porque o workflow (`clojure.yml`) só builda o
`clojure-api`, não o BFF.

## Correções

- Remove o import morto `useNavigate` (e a linha comentada que o usaria).
- Corrige o tipo do handler `onSubmit` de `FormEvent<HTMLInputElement>` para
  `FormEvent<HTMLFormElement>` — o tipo correto para o `onSubmit` de um `<form>`.

## Validação local

| Build | Resultado |
| ----- | --------- |
| `clojure-api` — `lein test` (JDK 21) | ✅ 12 testes, 18 asserções, 0 falhas |
| `clojure-api-bff` — `tsc && vite build` | ✅ `tsc` limpo, `vite v6.4.3` gerou `dist/` |

Confirma que **o vite 6 funciona** — o aviso de peer dependency do
`@vitejs/plugin-react` não é fatal.

> Nota: o CI deste PR vai aparecer vermelho pelo mesmo motivo dos outros — a
> conta está com o GitHub Actions travado por billing. Não é falha de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)